### PR TITLE
feat: get balances using offline signer

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
 		"prepare": "husky"
 	},
 	"dependencies": {
+		"@cosmjs/proto-signing": "^0.33.1",
+		"@cosmjs/stargate": "^0.33.1",
 		"@headlessui/react": "^2.2.2",
 		"@keplr-wallet/provider-extension": "^0.12.220",
 		"next": "15.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@cosmjs/proto-signing':
+    specifier: ^0.33.1
+    version: 0.33.1
+  '@cosmjs/stargate':
+    specifier: ^0.33.1
+    version: 0.33.1
   '@headlessui/react':
     specifier: ^2.2.2
     version: 2.2.2(react-dom@19.1.0)(react@19.1.0)
@@ -286,6 +292,128 @@ packages:
       '@types/conventional-commits-parser': 5.0.1
       chalk: 5.4.1
     dev: true
+
+  /@cosmjs/amino@0.33.1:
+    resolution:
+      { integrity: sha512-WfWiBf2EbIWpwKG9AOcsIIkR717SY+JdlXM/SL/bI66BdrhniAF+/ZNis9Vo9HF6lP2UU5XrSmFA4snAvEgdrg== }
+    dependencies:
+      '@cosmjs/crypto': 0.33.1
+      '@cosmjs/encoding': 0.33.1
+      '@cosmjs/math': 0.33.1
+      '@cosmjs/utils': 0.33.1
+    dev: false
+
+  /@cosmjs/crypto@0.33.1:
+    resolution:
+      { integrity: sha512-U4kGIj/SNBzlb2FGgA0sMR0MapVgJUg8N+oIAiN5+vl4GZ3aefmoL1RDyTrFS/7HrB+M+MtHsxC0tvEu4ic/zA== }
+    dependencies:
+      '@cosmjs/encoding': 0.33.1
+      '@cosmjs/math': 0.33.1
+      '@cosmjs/utils': 0.33.1
+      '@noble/hashes': 1.7.1
+      bn.js: 5.2.1
+      elliptic: 6.6.1
+      libsodium-wrappers-sumo: 0.7.15
+    dev: false
+
+  /@cosmjs/encoding@0.33.1:
+    resolution:
+      { integrity: sha512-nuNxf29fUcQE14+1p//VVQDwd1iau5lhaW/7uMz7V2AH3GJbFJoJVaKvVyZvdFk+Cnu+s3wCqgq4gJkhRCJfKw== }
+    dependencies:
+      base64-js: 1.5.1
+      bech32: 1.1.4
+      readonly-date: 1.0.0
+    dev: false
+
+  /@cosmjs/json-rpc@0.33.1:
+    resolution:
+      { integrity: sha512-T6VtWzecpmuTuMRGZWuBYHsMF/aznWCYUt/cGMWNSz7DBPipVd0w774PKpxXzpEbyt5sr61NiuLXc+Az15S/Cw== }
+    dependencies:
+      '@cosmjs/stream': 0.33.1
+      xstream: 11.14.0
+    dev: false
+
+  /@cosmjs/math@0.33.1:
+    resolution:
+      { integrity: sha512-ytGkWdKFCPiiBU5eqjHNd59djPpIsOjbr2CkNjlnI1Zmdj+HDkSoD9MUGpz9/RJvRir5IvsXqdE05x8EtoQkJA== }
+    dependencies:
+      bn.js: 5.2.1
+    dev: false
+
+  /@cosmjs/proto-signing@0.33.1:
+    resolution:
+      { integrity: sha512-Sv4W+MxX+0LVnd+2rU4Fw1HRsmMwSVSYULj7pRkij3wnPwUlTVoJjmKFgKz13ooIlfzPrz/dnNjGp/xnmXChFQ== }
+    dependencies:
+      '@cosmjs/amino': 0.33.1
+      '@cosmjs/crypto': 0.33.1
+      '@cosmjs/encoding': 0.33.1
+      '@cosmjs/math': 0.33.1
+      '@cosmjs/utils': 0.33.1
+      cosmjs-types: 0.9.0
+    dev: false
+
+  /@cosmjs/socket@0.33.1:
+    resolution:
+      { integrity: sha512-KzAeorten6Vn20sMiM6NNWfgc7jbyVo4Zmxev1FXa5EaoLCZy48cmT3hJxUJQvJP/lAy8wPGEjZ/u4rmF11x9A== }
+    dependencies:
+      '@cosmjs/stream': 0.33.1
+      isomorphic-ws: 4.0.1(ws@7.5.10)
+      ws: 7.5.10
+      xstream: 11.14.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /@cosmjs/stargate@0.33.1:
+    resolution:
+      { integrity: sha512-CnJ1zpSiaZgkvhk+9aTp5IPmgWn2uo+cNEBN8VuD9sD6BA0V4DMjqe251cNFLiMhkGtiE5I/WXFERbLPww3k8g== }
+    dependencies:
+      '@cosmjs/amino': 0.33.1
+      '@cosmjs/encoding': 0.33.1
+      '@cosmjs/math': 0.33.1
+      '@cosmjs/proto-signing': 0.33.1
+      '@cosmjs/stream': 0.33.1
+      '@cosmjs/tendermint-rpc': 0.33.1
+      '@cosmjs/utils': 0.33.1
+      cosmjs-types: 0.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+    dev: false
+
+  /@cosmjs/stream@0.33.1:
+    resolution:
+      { integrity: sha512-bMUvEENjeQPSTx+YRzVsWT1uFIdHRcf4brsc14SOoRQ/j5rOJM/aHfsf/BmdSAnYbdOQ3CMKj/8nGAQ7xUdn7w== }
+    dependencies:
+      xstream: 11.14.0
+    dev: false
+
+  /@cosmjs/tendermint-rpc@0.33.1:
+    resolution:
+      { integrity: sha512-22klDFq2MWnf//C8+rZ5/dYatr6jeGT+BmVbutXYfAK9fmODbtFcumyvB6uWaEORWfNukl8YK1OLuaWezoQvxA== }
+    dependencies:
+      '@cosmjs/crypto': 0.33.1
+      '@cosmjs/encoding': 0.33.1
+      '@cosmjs/json-rpc': 0.33.1
+      '@cosmjs/math': 0.33.1
+      '@cosmjs/socket': 0.33.1
+      '@cosmjs/stream': 0.33.1
+      '@cosmjs/utils': 0.33.1
+      axios: 1.8.4
+      readonly-date: 1.0.0
+      xstream: 11.14.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+    dev: false
+
+  /@cosmjs/utils@0.33.1:
+    resolution:
+      { integrity: sha512-UnLHDY6KMmC+UXf3Ufyh+onE19xzEXjT4VZ504Acmk4PXxqyvG4cCPprlKUFnGUX7f0z8Or9MAOHXBx41uHBcg== }
+    dev: false
 
   /@emnapi/core@1.4.3:
     resolution:
@@ -1756,6 +1884,11 @@ packages:
     engines: { node: '>= 0.4' }
     dev: true
 
+  /asynckit@0.4.0:
+    resolution:
+      { integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q== }
+    dev: false
+
   /available-typed-arrays@1.0.7:
     resolution:
       { integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ== }
@@ -1770,6 +1903,17 @@ packages:
     engines: { node: '>=4' }
     dev: true
 
+  /axios@1.8.4:
+    resolution:
+      { integrity: sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw== }
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.2
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /axobject-query@4.1.0:
     resolution:
       { integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ== }
@@ -1780,6 +1924,26 @@ packages:
     resolution:
       { integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw== }
     dev: true
+
+  /base64-js@1.5.1:
+    resolution:
+      { integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA== }
+    dev: false
+
+  /bech32@1.1.4:
+    resolution:
+      { integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ== }
+    dev: false
+
+  /bn.js@4.12.1:
+    resolution:
+      { integrity: sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg== }
+    dev: false
+
+  /bn.js@5.2.1:
+    resolution:
+      { integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ== }
+    dev: false
 
   /brace-expansion@1.1.11:
     resolution:
@@ -1804,6 +1968,11 @@ packages:
       fill-range: 7.1.1
     dev: true
 
+  /brorand@1.1.0:
+    resolution:
+      { integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w== }
+    dev: false
+
   /busboy@1.6.0:
     resolution:
       { integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA== }
@@ -1819,7 +1988,6 @@ packages:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
-    dev: true
 
   /call-bind@1.0.8:
     resolution:
@@ -1928,6 +2096,14 @@ packages:
     dev: false
     optional: true
 
+  /combined-stream@1.0.8:
+    resolution:
+      { integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg== }
+    engines: { node: '>= 0.8' }
+    dependencies:
+      delayed-stream: 1.0.0
+    dev: false
+
   /compare-func@2.0.0:
     resolution:
       { integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA== }
@@ -2000,6 +2176,11 @@ packages:
       parse-json: 5.2.0
       typescript: 5.8.3
     dev: true
+
+  /cosmjs-types@0.9.0:
+    resolution:
+      { integrity: sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ== }
+    dev: false
 
   /cross-spawn@7.0.6:
     resolution:
@@ -2101,7 +2282,6 @@ packages:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
-    dev: true
 
   /define-properties@1.2.1:
     resolution:
@@ -2111,7 +2291,12 @@ packages:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-    dev: true
+
+  /delayed-stream@1.0.0:
+    resolution:
+      { integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ== }
+    engines: { node: '>=0.4.0' }
+    dev: false
 
   /detect-libc@2.0.3:
     resolution:
@@ -2142,7 +2327,19 @@ packages:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-    dev: true
+
+  /elliptic@6.6.1:
+    resolution:
+      { integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g== }
+    dependencies:
+      bn.js: 4.12.1
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+    dev: false
 
   /emoji-regex@8.0.0:
     resolution:
@@ -2237,13 +2434,11 @@ packages:
     resolution:
       { integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g== }
     engines: { node: '>= 0.4' }
-    dev: true
 
   /es-errors@1.3.0:
     resolution:
       { integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw== }
     engines: { node: '>= 0.4' }
-    dev: true
 
   /es-iterator-helpers@1.2.1:
     resolution:
@@ -2274,7 +2469,6 @@ packages:
     engines: { node: '>= 0.4' }
     dependencies:
       es-errors: 1.3.0
-    dev: true
 
   /es-set-tostringtag@2.1.0:
     resolution:
@@ -2285,7 +2479,6 @@ packages:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-    dev: true
 
   /es-shim-unscopables@1.1.0:
     resolution:
@@ -2799,6 +2992,17 @@ packages:
       { integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg== }
     dev: true
 
+  /follow-redirects@1.15.9:
+    resolution:
+      { integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ== }
+    engines: { node: '>=4.0' }
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
   /for-each@0.3.5:
     resolution:
       { integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg== }
@@ -2806,6 +3010,17 @@ packages:
     dependencies:
       is-callable: 1.2.7
     dev: true
+
+  /form-data@4.0.2:
+    resolution:
+      { integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w== }
+    engines: { node: '>= 6' }
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      mime-types: 2.1.35
+    dev: false
 
   /fs-extra@10.1.0:
     resolution:
@@ -2819,7 +3034,6 @@ packages:
   /function-bind@1.1.2:
     resolution:
       { integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA== }
-    dev: true
 
   /function.prototype.name@1.1.8:
     resolution:
@@ -2859,7 +3073,6 @@ packages:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
-    dev: true
 
   /get-proto@1.0.1:
     resolution:
@@ -2868,7 +3081,6 @@ packages:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-    dev: true
 
   /get-symbol-description@1.1.0:
     resolution:
@@ -2935,13 +3147,11 @@ packages:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
-    dev: true
 
   /gopd@1.2.0:
     resolution:
       { integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg== }
     engines: { node: '>= 0.4' }
-    dev: true
 
   /graceful-fs@4.2.11:
     resolution:
@@ -2969,7 +3179,6 @@ packages:
       { integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg== }
     dependencies:
       es-define-property: 1.0.1
-    dev: true
 
   /has-proto@1.2.0:
     resolution:
@@ -2983,7 +3192,6 @@ packages:
     resolution:
       { integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ== }
     engines: { node: '>= 0.4' }
-    dev: true
 
   /has-tostringtag@1.0.2:
     resolution:
@@ -2991,7 +3199,14 @@ packages:
     engines: { node: '>= 0.4' }
     dependencies:
       has-symbols: 1.1.0
-    dev: true
+
+  /hash.js@1.1.7:
+    resolution:
+      { integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA== }
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+    dev: false
 
   /hasown@2.0.2:
     resolution:
@@ -2999,7 +3214,15 @@ packages:
     engines: { node: '>= 0.4' }
     dependencies:
       function-bind: 1.1.2
-    dev: true
+
+  /hmac-drbg@1.0.1:
+    resolution:
+      { integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg== }
+    dependencies:
+      hash.js: 1.1.7
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+    dev: false
 
   /husky@9.1.7:
     resolution:
@@ -3033,6 +3256,11 @@ packages:
       { integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA== }
     engines: { node: '>=0.8.19' }
     dev: true
+
+  /inherits@2.0.4:
+    resolution:
+      { integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ== }
+    dev: false
 
   /ini@4.1.1:
     resolution:
@@ -3308,6 +3536,15 @@ packages:
     transitivePeerDependencies:
       - encoding
 
+  /isomorphic-ws@4.0.1(ws@7.5.10):
+    resolution:
+      { integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w== }
+    peerDependencies:
+      ws: '*'
+    dependencies:
+      ws: 7.5.10
+    dev: false
+
   /isows@1.0.6(ws@8.18.1):
     resolution:
       { integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw== }
@@ -3435,6 +3672,18 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
     dev: true
+
+  /libsodium-sumo@0.7.15:
+    resolution:
+      { integrity: sha512-5tPmqPmq8T8Nikpm1Nqj0hBHvsLFCXvdhBFV7SGOitQPZAA6jso8XoL0r4L7vmfKXr486fiQInvErHtEvizFMw== }
+    dev: false
+
+  /libsodium-wrappers-sumo@0.7.15:
+    resolution:
+      { integrity: sha512-aSWY8wKDZh5TC7rMvEdTHoyppVq/1dTSAeAR7H6pzd6QRT3vQWcT5pGwCotLcpPEOLXX6VvqihSPkpEhYAjANA== }
+    dependencies:
+      libsodium-sumo: 0.7.15
+    dev: false
 
   /lightningcss-darwin-arm64@1.29.2:
     resolution:
@@ -3641,7 +3890,6 @@ packages:
     resolution:
       { integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g== }
     engines: { node: '>= 0.4' }
-    dev: true
 
   /meow@12.1.1:
     resolution:
@@ -3663,6 +3911,30 @@ packages:
       braces: 3.0.3
       picomatch: 2.3.1
     dev: true
+
+  /mime-db@1.52.0:
+    resolution:
+      { integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg== }
+    engines: { node: '>= 0.6' }
+    dev: false
+
+  /mime-types@2.1.35:
+    resolution:
+      { integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw== }
+    engines: { node: '>= 0.6' }
+    dependencies:
+      mime-db: 1.52.0
+    dev: false
+
+  /minimalistic-assert@1.0.1:
+    resolution:
+      { integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A== }
+    dev: false
+
+  /minimalistic-crypto-utils@1.0.1:
+    resolution:
+      { integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg== }
+    dev: false
 
   /minimatch@3.1.2:
     resolution:
@@ -3774,7 +4046,6 @@ packages:
     resolution:
       { integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA== }
     engines: { node: '>= 0.4' }
-    dev: true
 
   /object.assign@4.1.7:
     resolution:
@@ -4026,6 +4297,11 @@ packages:
       react-is: 16.13.1
     dev: true
 
+  /proxy-from-env@1.1.0:
+    resolution:
+      { integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg== }
+    dev: false
+
   /psl@1.15.0:
     resolution:
       { integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w== }
@@ -4074,6 +4350,11 @@ packages:
     resolution:
       { integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg== }
     engines: { node: '>=0.10.0' }
+    dev: false
+
+  /readonly-date@1.0.0:
+    resolution:
+      { integrity: sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ== }
     dev: false
 
   /redeyed@2.1.1:
@@ -4535,6 +4816,12 @@ packages:
     engines: { node: '>= 0.4' }
     dev: true
 
+  /symbol-observable@2.0.3:
+    resolution:
+      { integrity: sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA== }
+    engines: { node: '>=0.10' }
+    dev: false
+
   /synckit@0.11.4:
     resolution:
       { integrity: sha512-Q/XQKRaJiLiFIBNN+mndW7S/RHxvwzuZS6ZwmRzUBqJBv/5QIKCEwkBC8GBf8EQJKYnaFs0wOZbKTXBPj8L9oQ== }
@@ -4895,6 +5182,20 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  /ws@7.5.10:
+    resolution:
+      { integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ== }
+    engines: { node: '>=8.3.0' }
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
+
   /ws@8.18.1:
     resolution:
       { integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w== }
@@ -4907,6 +5208,14 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: false
+
+  /xstream@11.14.0:
+    resolution:
+      { integrity: sha512-1bLb+kKKtKPbgTK6i/BaoAn03g47PpFstlbe1BA+y3pNS/LfvcaghS5BFf9+EE1J+KwSQsEpfJvFN5GqFtiNmw== }
+    dependencies:
+      globalthis: 1.0.4
+      symbol-observable: 2.0.3
     dev: false
 
   /y18n@5.0.8:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,8 +18,8 @@ const SUB_NAVIGATION_ITEMS = [
 export default function DashboardPage() {
 	// State
 	const [activeTab, setActiveTab] = useState<(typeof SUB_NAVIGATION_ITEMS)[number]['id']>('overview')
-	const [usdnBalance, setUSDNBalance] = useState<string>('-')
-	const [usdcBalance, setUSDCBalance] = useState<string>('-')
+	const [usdnBalance, setUSDNBalance] = useState<string>('')
+	const [usdcBalance, setUSDCBalance] = useState<string>('')
 	// Hooks
 	const { totalSupply, totalHolders, totalYieldAccrued, getAccountBalance: getUSDNBalance } = useNobleDollarStats()
 	const { isConnected, account, getBalance } = useKeplrWallet()

--- a/src/components/NobleDollarStatsProvider.tsx
+++ b/src/components/NobleDollarStatsProvider.tsx
@@ -6,6 +6,8 @@ import { createContext, useContext, useEffect, useState } from 'react'
 import { BASE_API_URL, USDN_DENOM } from '$/lib/constants'
 import { toUSDN } from '$/utils/formatters'
 
+import { useKeplrWallet } from './KeplrWalletProvider'
+
 type NobleDollarStatsProviderProps = {
 	children: React.ReactNode
 }
@@ -36,6 +38,9 @@ export const NobleDollarStatsProvider = ({ children }: NobleDollarStatsProviderP
 	const [totalPrincipal, setTotalPrincipal] = useState(defaultValues.totalPrincipal)
 	const [totalYieldAccrued, setTotalYieldAccrued] = useState(defaultValues.totalYieldAccrued)
 
+	// Hooks
+	const { getBalance } = useKeplrWallet()
+
 	// API Fetchers
 	const getTotalSupply = async () => {
 		const url = `${BASE_API_URL}/cosmos/bank/v1beta1/supply/by_denom?denom=${USDN_DENOM}`
@@ -53,15 +58,16 @@ export const NobleDollarStatsProvider = ({ children }: NobleDollarStatsProviderP
 		setTotalYieldAccrued(toUSDN(data.total_yield_accrued))
 	}
 
-	// NOTE: For some reason, this endpoint is returning zero even when passing in the correct testnet bech32 address
-	const getAccountBalance = async (account: Key): Promise<string> => {
-		const url = `${BASE_API_URL}/cosmos/bank/v1beta1/balances/${account.bech32Address}/by_denom?denom=${USDN_DENOM}`
-		const response = await fetch(url)
-		const data = await response.json()
-		return toUSDN(data.balance.amount)
+	const getAccountBalance = async (): Promise<string> => {
+		// NOTE: For some reason, this endpoint is returning zero even when passing in the correct testnet bech32 address
+		// const url = `${BASE_API_URL}/cosmos/bank/v1beta1/balances/${account.bech32Address}/by_denom?denom=${USDN_DENOM}`
+		// const response = await fetch(url)
+		// const data = await response.json()
+		const balance = await getBalance(USDN_DENOM)
+		return toUSDN(balance)
 	}
 
-	// TODO: Stub out other endpoints and expose them. f it expands to other tokens, rename the provider to represent that (i.e. TokenStatsProvider)
+	// TODO: Stub out other endpoints and expose them. If it expands to other tokens, rename the provider to better represent that (i.e. TokenStatsProvider)
 
 	useEffect(() => {
 		getStats()

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,11 +1,18 @@
 // URLs
 export const BASE_API_URL = 'https://api.noble.xyz'
-export const NOBLE_TESTNET_RPC_URL = 'https://rpc.testnet.noble.xyz'
-export const NOBLE_MAINNET_RPC_URL = 'https://noble-rpc.polkachu.com'
 
-// Chain IDs
-export const NOBLE_MAINNET_CHAIN_ID = 'noble-1'
-export const NOBLE_TESTNET_CHAIN_ID = 'grand-1'
+// Networks
+export const SUPPORTED_NETWORKS = {
+	NOBLE_MAINNET: {
+		CHAIN_ID: 'noble-1',
+		RPC_URL: 'https://noble-rpc.polkachu.com',
+	},
+	NOBLE_TESTNET: {
+		CHAIN_ID: 'grand-1',
+		RPC_URL: 'https://rpc.testnet.noble.xyz',
+	},
+}
+export const PREFERRED_NETWORK = SUPPORTED_NETWORKS.NOBLE_TESTNET
 
 // USDN
 export const USDN_DENOM = 'uusdn'

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,6 +1,6 @@
 import { Address, formatUnits } from 'viem'
 
-import { DEFAULT_DECIMALS_PRECISION, USDN_DECIMALS } from '$/lib/constants'
+import { DEFAULT_DECIMALS_PRECISION, USDC_DECIMALS, USDC_DENOM, USDN_DECIMALS, USDN_DENOM } from '$/lib/constants'
 
 import { toBigInt } from './bigint'
 
@@ -12,6 +12,17 @@ import { toBigInt } from './bigint'
 export const toUSDN = (value: string | number | bigint | undefined | null): string => {
 	if (!value) return '-'
 	return formatUnits(toBigInt(value), USDN_DECIMALS)
+}
+
+export const toUSDC = (value: string | number | bigint | undefined | null): string => {
+	if (!value) return '-'
+	return formatUnits(toBigInt(value), USDC_DECIMALS)
+}
+
+export const displayDenom = (denom: string): string => {
+	if (denom === USDN_DENOM) return 'USDN'
+	if (denom === USDC_DENOM) return 'USDC'
+	return denom
 }
 
 /**


### PR DESCRIPTION
## Synopsis

Since there was an issue using the [Noble API](https://api.noble.xyz/#tag/bank/GET/cosmos/bank/v1beta1/balances/{address}/by_denom) endpoint on testnet, this uses the offline signer from `@cosmjs` to get account balances for different denominations instead.

### General Changes

- Swaps out calling the API for using the `SigningStargateClient` signing client to get balances
- Creates a generic `getBalance(denom)` handler in the `KeplrWalletProvider` component
- Dogfoods the generic handler and specifies it for getting USDN balances in the `NobleDollarStatsProvider`
- Uses the `getAccountBalance` in the presentational component to show the USDN balance for the connected account
- Adds additional token balances on the homepage 'Balances' tab; fetches the user's USDC balance using the generic `getBalance` helper

#### Testing (Before)

<img width="373" alt="image" src="https://github.com/user-attachments/assets/8841eb8d-512d-4715-a8fd-3b4d27e1c517" />
<img width="1258" alt="image" src="https://github.com/user-attachments/assets/58a1a51c-93f0-4260-bd51-92cc022dc3b6" />

#### Testing (After)

<img width="373" alt="image" src="https://github.com/user-attachments/assets/0715e090-24d4-415d-aa81-e810dc8d3495" />
<img width="1255" alt="image" src="https://github.com/user-attachments/assets/54c1e4a0-a71d-453a-bd68-91efac2ec140" />
